### PR TITLE
feat: Add Ansible playbooks for homelab deployment

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,34 @@
+# Ansible Playbooks for Homelab Deployment
+
+This directory contains Ansible playbooks to provision a server and deploy the homelab stack.
+
+## Prerequisites
+
+- A Debian-based server (e.g., Ubuntu 22.04 on Digital Ocean).
+- Your server's IP address added to an Ansible inventory file (e.g., `inventory.ini`).
+- Ansible installed on your local machine.
+
+## Usage
+
+### 1. Provision the Server
+
+This playbook installs Docker, Docker Compose, and Tailscale on your server. It also joins the server to your Tailscale network.
+
+```bash
+ansible-playbook -i inventory.ini playbooks/provision.yml --ask-become-pass --extra-vars "tailscale_auth_key=YOUR_TAILSCALE_AUTH_KEY"
+```
+
+Replace `YOUR_TAILSCALE_AUTH_KEY` with a valid Tailscale authentication key.
+
+### 2. Deploy the Application Stack
+
+This playbook deploys the `litellm`, `openwebui`, `caddy`, and database containers. It will prompt you for the necessary secrets and configuration values.
+
+```bash
+ansible-playbook -i inventory.ini playbooks/deploy.yml --ask-become-pass
+```
+
+After running this playbook, your services will be accessible via their Tailscale MagicDNS names:
+
+- **OpenWebUI:** `https://openwebui.homelab.your-tailnet.ts.net`
+- **LiteLLM:** `https://litellm.homelab.your-tailnet.ts.net`

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -1,0 +1,49 @@
+- name: Deploy application stack
+  hosts: all
+  become: true
+  vars_prompt:
+    - name: tailscale_api_key
+      prompt: "Enter your Tailscale API key"
+      private: true
+    - name: tailscale_domain
+      prompt: "Enter your Tailscale domain (e.g., your-tailnet.ts.net)"
+      private: false
+    - name: litellm_master_key
+      prompt: "Enter a master key for LiteLLM"
+      private: true
+    - name: postgres_password
+      prompt: "Enter a password for the Postgres database"
+      private: true
+      default: "litellm_password"
+    - name: webui_secret_key
+      prompt: "Enter a secret key for OpenWebUI"
+      private: true
+      default: "change_this_secret_key_in_production"
+  tasks:
+    - name: Create config directory
+      ansible.builtin.file:
+        path: /opt/homelab/config
+        state: directory
+        mode: '0755'
+
+    - name: Copy Caddyfile
+      ansible.builtin.template:
+        src: ../../config/Caddyfile
+        dest: /opt/homelab/config/Caddyfile
+
+    - name: Copy docker-compose.yml
+      ansible.builtin.template:
+        src: ../services/docker-compose.yml
+        dest: /opt/homelab/docker-compose.yml
+
+    - name: Create .env file
+      ansible.builtin.template:
+        dest: /opt/homelab/.env
+        src: templates/.env.j2
+
+    - name: Start services
+      community.docker.docker_compose:
+        project_src: /opt/homelab
+        env_file: /opt/homelab/.env
+        build: true
+      changed_when: false

--- a/ansible/playbooks/provision.yml
+++ b/ansible/playbooks/provision.yml
@@ -1,0 +1,69 @@
+- name: Provision server
+  hosts: all
+  become: true
+  vars:
+    tailscale_auth_key: "tskey-auth-kkTszdBnwh11CNTRL-7tYAviQqAz9QusnoWik2z9RZUVAUD1a5J"
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Install dependencies
+      ansible.builtin.apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg-agent
+          - software-properties-common
+        state: present
+
+    - name: Add Docker GPG key
+      ansible.builtin.get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /etc/apt/keyrings/docker.asc
+        mode: '0644'
+        force: true
+
+    - name: Add Docker repository
+      ansible.builtin.apt_repository:
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+
+    - name: Install Docker
+      ansible.builtin.apt:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+        state: present
+
+    - name: Install Docker Compose
+      ansible.builtin.get_url:
+        url: "https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64"
+        dest: /usr/local/bin/docker-compose
+        mode: '0755'
+
+    - name: Add Tailscale GPG key
+      ansible.builtin.get_url:
+        url: "https://pkgs.tailscale.com/stable/ubuntu/{{ ansible_distribution_release }}.noarmor.gpg"
+        dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
+        mode: '0644'
+        force: true
+
+    - name: Add Tailscale repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/ubuntu/{{ ansible_distribution_release }} stable"
+        state: present
+
+    - name: Install Tailscale
+      ansible.builtin.apt:
+        name: tailscale
+        state: present
+        update_cache: true
+
+    - name: Join Tailscale network
+      ansible.builtin.command:
+        cmd: "tailscale up --authkey {{ tailscale_auth_key }}"
+      changed_when: false

--- a/ansible/services/caddy/Dockerfile
+++ b/ansible/services/caddy/Dockerfile
@@ -1,0 +1,10 @@
+ARG CADDY_VERSION=2
+
+FROM caddy:${CADDY_VERSION}-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/tailscale
+
+FROM caddy:${CADDY_VERSION}
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/ansible/services/docker-compose.yml
+++ b/ansible/services/docker-compose.yml
@@ -1,4 +1,23 @@
 services:
+  caddy:
+    build:
+      context: ./caddy
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ../../config/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      - TAILSCALE_API_KEY=${TAILSCALE_API_KEY}
+      - TAILSCALE_DOMAIN=${TAILSCALE_DOMAIN}
+    networks:
+      - nix-demo
+
   litellm:
     image: ghcr.io/berriai/litellm:main-stable
     container_name: litellm
@@ -114,3 +133,5 @@ volumes:
   neo4j_import:
   neo4j_plugins:
   openwebui_data:
+  caddy_data:
+  caddy_config:

--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -1,0 +1,12 @@
+{
+    # ACME DNS-01 challenge with Tailscale
+    acme_dns tailscale {env.TAILSCALE_API_KEY}
+}
+
+openwebui.homelab.{{env.TAILSCALE_DOMAIN}}.ts.net {
+    reverse_proxy openwebui:8080
+}
+
+litellm.homelab.{{env.TAILSCALE_DOMAIN}}.ts.net {
+    reverse_proxy litellm:4000
+}


### PR DESCRIPTION
This commit introduces a set of Ansible playbooks to automate the deployment of a homelab stack, including LiteLLM, OpenWebUI, and databases.

The deployment is designed to be secure and private, using Tailscale and Caddy for MagicDNS and automatic HTTPS.

The changes include:
- A `provision.yml` playbook to set up a Debian-based server with Docker, Docker Compose, and Tailscale.
- A `deploy.yml` playbook to configure and launch the application stack using Docker Compose.
- A custom Caddy build with the Tailscale DNS plugin to enable MagicDNS.
- A `README.md` file with instructions for running the playbooks.